### PR TITLE
BDOG-987 Error handling

### DIFF
--- a/object-store-client-common/src/main/scala/uk/gov/hmrc/objectstore/client/model/categories.scala
+++ b/object-store-client-common/src/main/scala/uk/gov/hmrc/objectstore/client/model/categories.scala
@@ -17,6 +17,7 @@
 package uk.gov.hmrc.objectstore.client.model
 
 import scala.annotation.implicitNotFound
+import scala.language.higherKinds
 
 @implicitNotFound("""Cannot find an implicit Functor[${F}].
 If you are using Future, you may be missing an implicit ExecutionContext.""")
@@ -45,15 +46,4 @@ object Monad {
 
 object Functor {
   implicit def functorForMonad[F[_]](implicit F: Monad[F]): Functor[F] = F
-}
-
-trait NaturalTransformation[F[_], G[_]] {
-  def transform[A](f: F[A]): G[A]
-}
-
-object NaturalTransformation {
-  implicit def identity[F[_]]: NaturalTransformation[F, F] =
-    new NaturalTransformation[F, F] {
-      override def transform[A](f: F[A]): F[A] = f
-    }
 }

--- a/object-store-client-common/src/main/scala/uk/gov/hmrc/objectstore/client/model/http/HttpClient.scala
+++ b/object-store-client-common/src/main/scala/uk/gov/hmrc/objectstore/client/model/http/HttpClient.scala
@@ -16,13 +16,13 @@
 
 package uk.gov.hmrc.objectstore.client.model.http
 
-trait HttpClient[F[_], BODY, RES] {
+trait HttpClient[BODY, RES] {
 
-  def put(url: String, body: BODY, headers: List[(String, String)]): F[RES]
+  def put(url: String, body: BODY, headers: List[(String, String)]): RES
 
-  def post(url: String, body: BODY, headers: List[(String, String)]): F[RES]
+  def post(url: String, body: BODY, headers: List[(String, String)]): RES
 
-  def get(url: String, headers: List[(String, String)]): F[RES]
+  def get(url: String, headers: List[(String, String)]): RES
 
-  def delete(url: String, headers: List[(String, String)]): F[RES]
+  def delete(url: String, headers: List[(String, String)]): RES
 }

--- a/object-store-client-common/src/main/scala/uk/gov/hmrc/objectstore/client/model/http/ObjectStoreContentRead.scala
+++ b/object-store-client-common/src/main/scala/uk/gov/hmrc/objectstore/client/model/http/ObjectStoreContentRead.scala
@@ -16,23 +16,28 @@
 
 package uk.gov.hmrc.objectstore.client.model.http
 
+import uk.gov.hmrc.objectstore.client.model.objectstore.Object
 import uk.gov.hmrc.objectstore.client.model.{Functor, Monad}
 
 import scala.language.higherKinds
 
-trait ObjectStoreContentRead[F[_], RES, CONTENT] { outer =>
+trait ObjectStoreContentRead[F[_], RES_BODY, CONTENT] { outer =>
 
-  def readContent(response: RES): F[CONTENT]
+  def readContent(response: F[Option[Object[RES_BODY]]]): F[Option[Object[CONTENT]]]
 
-  def map[CONTENT2](fn: CONTENT => CONTENT2)(implicit F: Functor[F]): ObjectStoreContentRead[F, RES, CONTENT2] =
-    new ObjectStoreContentRead[F, RES, CONTENT2] {
-      override def readContent(response: RES): F[CONTENT2] =
-        F.map(outer.readContent(response))(fn)
+  def map[CONTENT2](fn: CONTENT => CONTENT2)(implicit F: Functor[F]): ObjectStoreContentRead[F, RES_BODY, CONTENT2] =
+    new ObjectStoreContentRead[F, RES_BODY, CONTENT2] {
+      override def readContent(response: F[Option[Object[RES_BODY]]]): F[Option[Object[CONTENT2]]] = {
+        F.map(outer.readContent(response))(_.map(obj => obj.copy(content = fn(obj.content))))
+      }
     }
 
-  def mapF[CONTENT2](fn: CONTENT => F[CONTENT2])(implicit F: Monad[F]): ObjectStoreContentRead[F, RES, CONTENT2] =
-    new ObjectStoreContentRead[F, RES, CONTENT2] {
-      override def readContent(response: RES): F[CONTENT2] =
-        F.flatMap(outer.readContent(response))(fn)
+  def mapF[CONTENT2](fn: CONTENT => F[CONTENT2])(implicit F: Monad[F]): ObjectStoreContentRead[F, RES_BODY, CONTENT2] =
+    new ObjectStoreContentRead[F, RES_BODY, CONTENT2] {
+      override def readContent(response: F[Option[Object[RES_BODY]]]): F[Option[Object[CONTENT2]]] =
+        F.flatMap(outer.readContent(response)) {
+          case Some(obj) => F.map(fn(obj.content))(content => Some(obj.copy(content = content)))
+          case _ => F.pure(None)
+        }
     }
 }

--- a/object-store-client-common/src/main/scala/uk/gov/hmrc/objectstore/client/model/http/ObjectStoreRead.scala
+++ b/object-store-client-common/src/main/scala/uk/gov/hmrc/objectstore/client/model/http/ObjectStoreRead.scala
@@ -20,11 +20,11 @@ import uk.gov.hmrc.objectstore.client.model.objectstore.{Object, ObjectListing}
 
 import scala.language.higherKinds
 
-trait ObjectStoreRead[F[_], RES] {
+trait ObjectStoreRead[F[_], RES, RES_BODY] { self =>
 
   def toObjectListing(response: RES): F[ObjectListing]
 
-  def toObject[CONTENT](location: String, response: RES, toContent: RES => F[CONTENT]): F[Option[Object[CONTENT]]]
+  def toObject(location: String, response: RES): F[Option[Object[RES_BODY]]]
 
   def consume(response: RES): F[Unit]
 }

--- a/object-store-client-play-26/src/main/scala/uk/gov/hmrc/objectstore/client/play/PlayMonads.scala
+++ b/object-store-client-play-26/src/main/scala/uk/gov/hmrc/objectstore/client/play/PlayMonads.scala
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.objectstore.client.play
+
+import scala.concurrent.{ExecutionContext, Future}
+
+
+trait PlayMonads {
+
+  implicit def futureEitherMonad(implicit ec: ExecutionContext): PlayMonad[FutureEither] =
+    new PlayMonad[FutureEither] {
+      override def pure[A](a: A): FutureEither[A] =
+        Future.successful(Right(a))
+
+      override def flatMap[A, B](fa: FutureEither[A])(fn: A => FutureEither[B]): FutureEither[B] =
+        fa.flatMap {
+          case Right(a) => fn(a)
+          case Left(e) => raiseError(e)
+        }
+
+      override def map[A, B](fa: FutureEither[A])(fn: A => B): FutureEither[B] =
+        fa.map(_.right.map(fn))
+
+      def raiseError[A](e: PlayObjectStoreException): FutureEither[A] =
+        Future.successful(Left(e))
+
+      def liftFuture[A](future: Future[A]): FutureEither[A] =
+        future.map(Right(_))
+    }
+
+  implicit def futureMonad(implicit ec: ExecutionContext): PlayMonad[Future] =
+    new PlayMonad[Future] {
+
+      override def pure[A](a: A): Future[A] = Future.successful(a)
+
+      override def flatMap[A, B](fa: Future[A])(fn: A => Future[B]): Future[B] = fa.flatMap(fn)
+
+      override def liftFuture[A](future: Future[A]): Future[A] = future
+
+      override def raiseError[A](e: PlayObjectStoreException): Future[A] = Future.failed(e)
+    }
+
+}

--- a/object-store-client-play-26/src/main/scala/uk/gov/hmrc/objectstore/client/play/PlayObjectStoreClient.scala
+++ b/object-store-client-play-26/src/main/scala/uk/gov/hmrc/objectstore/client/play/PlayObjectStoreClient.scala
@@ -16,42 +16,30 @@
 
 package uk.gov.hmrc.objectstore.client.play
 
+import akka.NotUsed
+import akka.stream.scaladsl.Source
+import akka.util.ByteString
 import javax.inject.{Inject, Singleton}
 import uk.gov.hmrc.objectstore.client.ObjectStoreClient
 import uk.gov.hmrc.objectstore.client.config.ObjectStoreClientConfig
-import uk.gov.hmrc.objectstore.client.model.NaturalTransformation
+import uk.gov.hmrc.objectstore.client.play.Implicits._
 
 import scala.concurrent.{ExecutionContext, Future}
-
 
 @Singleton
 class PlayObjectStoreClientEither @Inject()(
   httpClient: PlayWSHttpClient,
-  read      : PlayObjectStoreReads,
   config    : ObjectStoreClientConfig
-)(implicit ec: ExecutionContext
-) extends ObjectStoreClient[F, F, Request, Response](
-  httpClient, read, config
+)(implicit ec  : ExecutionContext
+) extends ObjectStoreClient[FutureEither, Request, Response, Source[ByteString, NotUsed]](
+  httpClient, PlayObjectStoreReads.futureEitherReads, config
 )
 
 @Singleton
 class PlayObjectStoreClient @Inject()(
   httpClient: PlayWSHttpClient,
-  read      : PlayObjectStoreReads,
   config    : ObjectStoreClientConfig
-)(implicit ec: ExecutionContext
-) extends ObjectStoreClient[F, Future, Request, Response](
-  httpClient, read, config
-)(implicitly, PlayObjectStoreClient.fToFuture)
-
-object PlayObjectStoreClient {
-  private def fToFuture(implicit ec: ExecutionContext): NaturalTransformation[F, Future] =
-    new NaturalTransformation[F, Future] {
-      override def transform[A](f: F[A]): Future[A] =
-        f.flatMap {
-          case Right(a) => Future.successful(a)
-          case Left(e)  => Future.failed(e)
-        }
-    }
-
-}
+)(implicit ec  : ExecutionContext
+) extends ObjectStoreClient[Future, Request, Response, Source[ByteString, NotUsed]](
+  httpClient, PlayObjectStoreReads.futureReads, config
+)

--- a/object-store-client-play-26/src/main/scala/uk/gov/hmrc/objectstore/client/play/PlayObjectStoreContentWrites.scala
+++ b/object-store-client-play-26/src/main/scala/uk/gov/hmrc/objectstore/client/play/PlayObjectStoreContentWrites.scala
@@ -25,16 +25,14 @@ import akka.util.ByteString
 import play.api.libs.Files.SingletonTemporaryFileCreator
 import play.api.libs.ws.WSRequest
 import uk.gov.hmrc.objectstore.client.model.http.{ObjectStoreContentWrite, Payload}
-import uk.gov.hmrc.objectstore.client.play.PlayWSHttpClient.Request
 
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.ExecutionContext
 
 trait PlayObjectStoreContentWrites {
-
-  implicit def payloadAkkaSourceContentWrite[Mat <: Any]: ObjectStoreContentWrite[Future, Payload[Source[ByteString, Mat]], Request] =
-    new ObjectStoreContentWrite[Future, Payload[Source[ByteString, Mat]], Request] {
-      override def writeContent(payload: Payload[Source[ByteString, Mat]]): Future[Request] =
-        Future.successful(
+  implicit def payloadAkkaSourceContentWrite[Mat <: Any](implicit ec: ExecutionContext): ObjectStoreContentWrite[F, Payload[Source[ByteString, Mat]], Request] =
+    new ObjectStoreContentWrite[F, Payload[Source[ByteString, Mat]], Request] {
+      override def writeContent(payload: Payload[Source[ByteString, Mat]]): F[Request] =
+        F.pure(
           HttpBody(
             length    = Some(payload.length),
             md5       = Some(payload.md5Hash),
@@ -44,8 +42,8 @@ trait PlayObjectStoreContentWrites {
         )
     }
 
-  implicit val fileWrite: ObjectStoreContentWrite[Future, File, Request] =
-    payloadAkkaSourceContentWrite.contramap { file =>
+  implicit def fileWrite(implicit ec: ExecutionContext): ObjectStoreContentWrite[F, File, Request] =
+    payloadAkkaSourceContentWrite[NotUsed].contramap { file =>
       Payload(
         length  = file.length,
         md5Hash = Md5Hash.fromInputStream(new FileInputStream(file)),
@@ -53,9 +51,9 @@ trait PlayObjectStoreContentWrites {
       )
     }
 
-  implicit def akkaSourceContentWrite[Mat <: Any](implicit ec: ExecutionContext, m: Materializer): ObjectStoreContentWrite[Future, Source[ByteString, Mat], Request] =
-    new ObjectStoreContentWrite[Future, Source[ByteString, Mat], Request] {
-      override def writeContent(content: Source[ByteString, Mat]): Future[Request] = {
+  implicit def akkaSourceContentWrite[Mat <: Any](implicit ec: ExecutionContext, m: Materializer): ObjectStoreContentWrite[F, Source[ByteString, Mat], Request] =
+    new ObjectStoreContentWrite[F, Source[ByteString, Mat], Request] {
+      override def writeContent(content: Source[ByteString, Mat]): F[Request] = {
         val tempFile = SingletonTemporaryFileCreator.create()
 
         val (uploadFinished, md5Finished) =
@@ -65,16 +63,18 @@ trait PlayObjectStoreContentWrites {
             sink2  = Md5Hash.md5HashSink
           ).run()
 
-        for {
-          _       <- uploadFinished
-          md5Hash <- md5Finished
-        } yield
-          HttpBody(
-            length    = Some(tempFile.path.toFile.length),
-            md5       = Some(md5Hash),
-            writeBody = (req: WSRequest) => req.withBody(tempFile.path.toFile),
-            release   = () => SingletonTemporaryFileCreator.delete(tempFile)
-          )
+        F.liftFuture(
+          for {
+            _       <- uploadFinished
+            md5Hash <- md5Finished
+          } yield
+            HttpBody(
+              length    = Some(tempFile.path.toFile.length),
+              md5       = Some(md5Hash),
+              writeBody = (req: WSRequest) => req.withBody(tempFile.path.toFile),
+              release   = () => SingletonTemporaryFileCreator.delete(tempFile)
+            )
+        )
       }
     }
 
@@ -93,8 +93,8 @@ trait PlayObjectStoreContentWrites {
         ClosedShape
     })
 
-  implicit lazy val bytesWrite: ObjectStoreContentWrite[Future, Array[Byte], Request] =
-    payloadAkkaSourceContentWrite.contramap { bytes =>
+  implicit def bytesWrite(implicit ec: ExecutionContext): ObjectStoreContentWrite[F, Array[Byte], Request] =
+    payloadAkkaSourceContentWrite[NotUsed].contramap { bytes =>
       Payload(
         length  = bytes.length,
         md5Hash = Md5Hash.fromBytes(bytes),
@@ -102,8 +102,6 @@ trait PlayObjectStoreContentWrites {
       )
     }
 
-  implicit lazy val stringWrite: ObjectStoreContentWrite[Future, String, Request] =
+  implicit def stringWrite(implicit ec: ExecutionContext): ObjectStoreContentWrite[F, String, Request] =
     bytesWrite.contramap(_.getBytes)
 }
-
-object PlayObjectStoreContentWrites extends PlayObjectStoreContentWrites

--- a/object-store-client-play-26/src/main/scala/uk/gov/hmrc/objectstore/client/play/PlayObjectStoreReads.scala
+++ b/object-store-client-play-26/src/main/scala/uk/gov/hmrc/objectstore/client/play/PlayObjectStoreReads.scala
@@ -19,64 +19,86 @@ package uk.gov.hmrc.objectstore.client.play
 import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter.RFC_1123_DATE_TIME
 
-import javax.inject.{Inject, Singleton}
+import akka.NotUsed
+import akka.stream.scaladsl.Source
+import akka.util.ByteString
 import play.api.http.Status
 import play.api.libs.json.{JsError, JsSuccess, JsValue}
-import play.api.libs.ws.WSResponse
 import uk.gov.hmrc.objectstore.client.model.http.ObjectStoreRead
 import uk.gov.hmrc.objectstore.client.model.objectstore.{Object, ObjectListing, ObjectMetadata}
 
-import scala.concurrent.ExecutionContext
+import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success, Try}
 
-@Singleton
-class PlayObjectStoreReads @Inject()(implicit ec: ExecutionContext) extends ObjectStoreRead[F, WSResponse]{
-  override def toObjectListing(response: WSResponse): F[ObjectListing] =
-    response match {
-      case r if Status.isSuccessful(r.status) => r.body[JsValue].validate[ObjectListing](PlayFormats.objectListingRead) match {
-        case JsSuccess(r, path) => F.pure(r)
-        case JsError(errors) => F.raiseError(OtherError(errors.toString))
+
+object PlayObjectStoreReads {
+
+  def futureEitherReads(implicit ec: ExecutionContext): ObjectStoreRead[FutureEither, Response, Source[ByteString, NotUsed]] = new ObjectStoreRead[FutureEither, Response, Source[ByteString, NotUsed]] {
+    override def toObjectListing(response: Response): FutureEither[ObjectListing] =
+      response.map {
+        case r if Status.isSuccessful(r.status) => r.body[JsValue].validate[ObjectListing](PlayFormats.objectListingRead) match {
+          case JsSuccess(r, path) => Right(r)
+          case JsError(errors) => Left(OtherError(errors.toString))
+        }
+        case r => Left(UpstreamErrorResponse(s"Object store call failed with status code: ${r.status}", r.status))
       }
-      case r => F.raiseError(UpstreamErrorResponse(s"Object store call failed with status code: ${r.status}", r.status))
-    }
 
-  override def toObject[CONTENT](location: String, response: WSResponse, readContent: WSResponse => F[CONTENT]): F[Option[Object[CONTENT]]] =
-    response match {
-      case r if Status.isSuccessful(r.status) =>
-        F.flatMap(readContent(r)){ content =>
-          def header(k: String): F[String] =
-            r.header(k).map(F.pure).getOrElse(F.raiseError(OtherError(s"Missing header $k")))
+    override def toObject(location: String, response: Response): FutureEither[Option[Object[Source[ByteString, NotUsed]]]] = {
+      response.map {
+        case resp@r if Status.isSuccessful(r.status) =>
+          def header(k: String): Either[PlayObjectStoreException, String] =
+            r.header(k).map(Right(_)).getOrElse(Left(OtherError(s"Missing header $k")))
 
-          def attempt[A](h: String, v: => A): F[A] =
+          def attempt[A](h: String, v: => A): Either[PlayObjectStoreException, A] =
             Try(v) match {
-              case Success(s) => F.pure(s)
-              case Failure(e) => F.raiseError(OtherError(s"Couldn't read header $h: ${e.getMessage}"))
+              case Success(s) => Right(s)
+              case Failure(e) => Left(OtherError(s"Couldn't read header $h: ${e.getMessage}"))
             }
 
-          F.flatMap(F.flatMap(header("Content-Length"))(cl => attempt("Content-Length", cl.toLong)))(contentLength =>
-            F.flatMap(header("Content-MD5"))(contentMd5 =>
-              F.map(F.flatMap(header("Last-Modified"))(lm => attempt("Last-Modified", ZonedDateTime.parse(lm, RFC_1123_DATE_TIME).toInstant)))(lastModified =>
-                Some(Object(
-                location = location,
-                content  = content,
-                metadata = ObjectMetadata(
-                  contentType   = r.contentType,
-                  contentLength = contentLength,
-                  contentMd5    = contentMd5,
-                  lastModified  = lastModified,
-                  userMetadata  = Map.empty[String, String] // TODO userMetadata?
-                )))
-              )
-            )
-          )
-        }
-      case r if r.status == Status.NOT_FOUND => F.pure(None)
-      case r => F.raiseError(UpstreamErrorResponse(s"Object store call failed with status code: ${r.status}", r.status))
+          for {
+            cl <- header("Content-Length").right
+            contentLength <- attempt("Content-Length", cl.toLong).right
+            contentMd5 <- header("Content-MD5").right
+            lm <- header("Last-Modified").right
+            lastModified <- attempt("Last-Modified", ZonedDateTime.parse(lm, RFC_1123_DATE_TIME).toInstant).right
+          } yield {
+            Some(Object(
+              location = location,
+              content = resp.bodyAsSource.mapMaterializedValue(_ => NotUsed),
+              metadata = ObjectMetadata(
+                contentType = r.contentType,
+                contentLength = contentLength,
+                contentMd5 = contentMd5,
+                lastModified = lastModified,
+                userMetadata = Map.empty[String, String] // TODO userMetadata?
+              )))
+          }
+
+        case r if r.status == Status.NOT_FOUND => Right(None)
+        case r => Left(UpstreamErrorResponse(s"Object store call failed with status code: ${r.status}", r.status))
+      }
     }
 
-  override def consume(response: WSResponse): F[Unit] =
-    response match {
-      case r if Status.isSuccessful(r.status) => F.pure(())
-      case r => F.raiseError(UpstreamErrorResponse(s"Object store call failed with status code: ${r.status}", r.status))
+    override def consume(response: Response): FutureEither[Unit] = {
+      response.map {
+        case r if Status.isSuccessful(r.status) => Right(())
+        case r => Left(UpstreamErrorResponse(s"Object store call failed with status code: ${r.status}", r.status))
+      }
     }
+  }
+
+  def futureReads(implicit ec: ExecutionContext): ObjectStoreRead[Future, Response, Source[ByteString, NotUsed]] = new ObjectStoreRead[Future, Response, Source[ByteString, NotUsed]] {
+
+    private def transform[A](f: FutureEither[A]): Future[A] =
+      f.flatMap {
+        case Right(a) => Future.successful(a)
+        case Left(e) => Future.failed(e)
+      }
+
+    override def toObjectListing(response: Response): Future[ObjectListing] = transform(futureEitherReads.toObjectListing(response))
+
+    override def toObject(location: String, response: Response): Future[Option[Object[Source[ByteString, NotUsed]]]] = transform(futureEitherReads.toObject(location, response))
+
+    override def consume(response: Response): Future[Unit] = transform(futureEitherReads.consume(response))
+  }
 }

--- a/object-store-client-play-26/src/main/scala/uk/gov/hmrc/objectstore/client/play/PlayObjectStoreReads.scala
+++ b/object-store-client-play-26/src/main/scala/uk/gov/hmrc/objectstore/client/play/PlayObjectStoreReads.scala
@@ -16,51 +16,67 @@
 
 package uk.gov.hmrc.objectstore.client.play
 
-
 import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter.RFC_1123_DATE_TIME
 
 import javax.inject.{Inject, Singleton}
 import play.api.http.Status
-import play.api.libs.json.JsValue
+import play.api.libs.json.{JsError, JsSuccess, JsValue}
 import play.api.libs.ws.WSResponse
 import uk.gov.hmrc.objectstore.client.model.http.ObjectStoreRead
 import uk.gov.hmrc.objectstore.client.model.objectstore.{Object, ObjectListing, ObjectMetadata}
 
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.ExecutionContext
+import scala.util.{Failure, Success, Try}
 
 @Singleton
-class PlayObjectStoreReads @Inject()(implicit ec: ExecutionContext) extends ObjectStoreRead[Future, WSResponse] {
-  override def toObjectListing(response: WSResponse): Future[ObjectListing] =
+class PlayObjectStoreReads @Inject()(implicit ec: ExecutionContext) extends ObjectStoreRead[F, WSResponse]{
+  override def toObjectListing(response: WSResponse): F[ObjectListing] =
     response match {
-      case r if Status.isSuccessful(r.status) => Future.successful(r.body[JsValue].as[ObjectListing](PlayFormats.objectListingRead))
-      case r => Future.failed(UpstreamErrorResponse("Object store call failed", r.status))
-    }
-
-  override def toObject[CONTENT](location: String, response: WSResponse, readContent: WSResponse => Future[CONTENT]): Future[Option[Object[CONTENT]]] =
-    response match {
-      case r if Status.isSuccessful(r.status) => readContent(r).map { c =>
-        def header(k: String) =
-          r.header(k).getOrElse(sys.error(s"Missing header $k"))// TODO raise error as non-UpstreamErrorResponse
-
-        Some(Object(
-          location = location,
-          content  = c,
-          metadata = ObjectMetadata(
-            contentType   = r.contentType,
-            contentLength = header("Content-Length").toLong,
-            contentMd5    = header("Content-MD5"),
-            lastModified  = ZonedDateTime.parse(header("Last-Modified"), RFC_1123_DATE_TIME).toInstant,
-            userMetadata  = Map.empty[String, String] // TODO userMetadata?
-          )))
+      case r if Status.isSuccessful(r.status) => r.body[JsValue].validate[ObjectListing](PlayFormats.objectListingRead) match {
+        case JsSuccess(r, path) => F.pure(r)
+        case JsError(errors) => F.raiseError(OtherError(errors.toString))
       }
-      case r if r.status == Status.NOT_FOUND => Future.successful(None)
-      case r => Future.failed(UpstreamErrorResponse("Object store call failed", r.status))
+      case r => F.raiseError(UpstreamErrorResponse(s"Object store call failed with status code: ${r.status}", r.status))
     }
 
-  override def consume(response: WSResponse): Future[Unit] =
+  override def toObject[CONTENT](location: String, response: WSResponse, readContent: WSResponse => F[CONTENT]): F[Option[Object[CONTENT]]] =
     response match {
-      case r if Status.isSuccessful(r.status) => Future.successful(())
-      case r => Future.failed(UpstreamErrorResponse("Object store call failed", r.status))
+      case r if Status.isSuccessful(r.status) =>
+        F.flatMap(readContent(r)){ content =>
+          def header(k: String): F[String] =
+            r.header(k).map(F.pure).getOrElse(F.raiseError(OtherError(s"Missing header $k")))
+
+          def attempt[A](h: String, v: => A): F[A] =
+            Try(v) match {
+              case Success(s) => F.pure(s)
+              case Failure(e) => F.raiseError(OtherError(s"Couldn't read header $h: ${e.getMessage}"))
+            }
+
+          F.flatMap(F.flatMap(header("Content-Length"))(cl => attempt("Content-Length", cl.toLong)))(contentLength =>
+            F.flatMap(header("Content-MD5"))(contentMd5 =>
+              F.map(F.flatMap(header("Last-Modified"))(lm => attempt("Last-Modified", ZonedDateTime.parse(lm, RFC_1123_DATE_TIME).toInstant)))(lastModified =>
+                Some(Object(
+                location = location,
+                content  = content,
+                metadata = ObjectMetadata(
+                  contentType   = r.contentType,
+                  contentLength = contentLength,
+                  contentMd5    = contentMd5,
+                  lastModified  = lastModified,
+                  userMetadata  = Map.empty[String, String] // TODO userMetadata?
+                )))
+              )
+            )
+          )
+        }
+      case r if r.status == Status.NOT_FOUND => F.pure(None)
+      case r => F.raiseError(UpstreamErrorResponse(s"Object store call failed with status code: ${r.status}", r.status))
+    }
+
+  override def consume(response: WSResponse): F[Unit] =
+    response match {
+      case r if Status.isSuccessful(r.status) => F.pure(())
+      case r => F.raiseError(UpstreamErrorResponse(s"Object store call failed with status code: ${r.status}", r.status))
     }
 }

--- a/object-store-client-play-26/src/main/scala/uk/gov/hmrc/objectstore/client/play/package.scala
+++ b/object-store-client-play-26/src/main/scala/uk/gov/hmrc/objectstore/client/play/package.scala
@@ -19,38 +19,18 @@ package uk.gov.hmrc.objectstore.client
 import _root_.play.api.libs.ws.{WSRequest, WSResponse}
 import uk.gov.hmrc.objectstore.client.model.{Monad, MonadError}
 
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.Future
 
 package object play {
   type Request  = HttpBody[WSRequest => WSRequest]
-  type Response = WSResponse
+  type Response = Future[WSResponse]
 
-  type F[A] = Future[Either[PlayObjectStoreException, A]]
-
-  implicit def F(implicit ec: ExecutionContext): PlayMonad[F] =
-    new PlayMonad[F] {
-      override def pure[A](a: A): F[A] =
-        Future.successful(Right(a))
-
-      override def flatMap[A, B](fa: F[A])(fn: A => F[B]): F[B] =
-        fa.flatMap {
-          case Right(a) => fn(a)
-          case Left(e)  => raiseError(e)
-        }
-
-      override def map[A, B](fa: F[A])(fn: A => B): F[B] =
-        fa.map(_.right.map(fn))
-
-      def raiseError[A](e: PlayObjectStoreException): F[A] =
-        Future.successful(Left(e))
-
-      def liftFuture[A](future: Future[A]): F[A] =
-        future.map(Right(_))
-    }
+  type FutureEither[A] = Future[Either[PlayObjectStoreException, A]]
 
   object Implicits
-    extends PlayObjectStoreContentReads
-       with PlayObjectStoreContentWrites {
+      extends PlayObjectStoreContentReads
+      with PlayObjectStoreContentWrites
+      with PlayMonads {
 
       object InMemoryReads extends InMemoryPlayObjectStoreContentReads
   }

--- a/object-store-client-play-26/src/main/scala/uk/gov/hmrc/objectstore/client/play/package.scala
+++ b/object-store-client-play-26/src/main/scala/uk/gov/hmrc/objectstore/client/play/package.scala
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.objectstore.client
+
+import _root_.play.api.libs.ws.{WSRequest, WSResponse}
+import uk.gov.hmrc.objectstore.client.model.{Monad, MonadError}
+
+import scala.concurrent.{ExecutionContext, Future}
+
+package object play {
+  type Request  = HttpBody[WSRequest => WSRequest]
+  type Response = WSResponse
+
+  type F[A] = Future[Either[PlayObjectStoreException, A]]
+
+  implicit def F(implicit ec: ExecutionContext): PlayMonad[F] =
+    new PlayMonad[F] {
+      override def pure[A](a: A): F[A] =
+        Future.successful(Right(a))
+
+      override def flatMap[A, B](fa: F[A])(fn: A => F[B]): F[B] =
+        fa.flatMap {
+          case Right(a) => fn(a)
+          case Left(e)  => raiseError(e)
+        }
+
+      override def map[A, B](fa: F[A])(fn: A => B): F[B] =
+        fa.map(_.right.map(fn))
+
+      def raiseError[A](e: PlayObjectStoreException): F[A] =
+        Future.successful(Left(e))
+
+      def liftFuture[A](future: Future[A]): F[A] =
+        future.map(Right(_))
+    }
+
+  object Implicits
+    extends PlayObjectStoreContentReads
+       with PlayObjectStoreContentWrites {
+
+      object InMemoryReads extends InMemoryPlayObjectStoreContentReads
+  }
+}
+
+package play {
+  abstract class PlayObjectStoreException(message: String) extends Exception(message)
+  case class UpstreamErrorResponse(message: String, statusCode: Int) extends PlayObjectStoreException(message)
+  case class OtherError(message: String) extends PlayObjectStoreException(message)
+
+  // TODO move this into common (and empty implementation) ?
+  // relationship with Payload?
+  case class HttpBody[BODY](length: Option[Long], md5: Option[String], writeBody: BODY, release: () => Unit)
+
+  // the play implementation operates over Future - this allows us to embed any Future into the operating F
+  // without requiring a full Monad Transformer stack
+  trait MonadFuture[F[_]] extends Monad[F] {
+    def liftFuture[A](future: Future[A]): F[A]
+  }
+
+  // simplify by unifying the type classes required for the Play implementations
+  trait PlayMonad[F[_]] extends MonadError[F, PlayObjectStoreException] with MonadFuture[F]
+}

--- a/object-store-client-play-26/src/test/scala/uk/gov/hmrc/objectstore/client/play/PlayObjectStoreClientEitherSpec.scala
+++ b/object-store-client-play-26/src/test/scala/uk/gov/hmrc/objectstore/client/play/PlayObjectStoreClientEitherSpec.scala
@@ -156,7 +156,7 @@ class PlayObjectStoreClientEitherSpec
 
       initGetObjectStub(location, statusCode = 200, Some(body))
 
-      import InMemoryReads._
+      import InMemoryReads.stringContentRead
 
       val obj = osClient.getObject[String](location).futureValue.right.value
       obj.get.content shouldBe body
@@ -174,7 +174,7 @@ class PlayObjectStoreClientEitherSpec
 
       initGetObjectStub(location, statusCode = 200, Some(body))
 
-      import InMemoryReads._
+      import InMemoryReads.jsValueContentRead
 
       val obj = osClient.getObject[JsValue](location).futureValue.right.value
       obj.get.content shouldBe JsObject(Seq("k1" -> JsString("v1"), "k2" -> JsString("v2")))
@@ -186,7 +186,7 @@ class PlayObjectStoreClientEitherSpec
 
       initGetObjectStub(location, statusCode = 200, Some(body))
 
-      import InMemoryReads._
+      import InMemoryReads.jsValueContentRead
 
       osClient.getObject[JsValue](location).futureValue.left.value shouldBe an[PlayObjectStoreException]
     }

--- a/object-store-client-play-26/src/test/scala/uk/gov/hmrc/objectstore/client/play/PlayObjectStoreClientSpec.scala
+++ b/object-store-client-play-26/src/test/scala/uk/gov/hmrc/objectstore/client/play/PlayObjectStoreClientSpec.scala
@@ -155,7 +155,7 @@ class PlayObjectStoreClientSpec
 
       initGetObjectStub(location, statusCode = 200, Some(body))
 
-      import InMemoryReads._
+      import InMemoryReads.stringContentRead
 
       val obj = osClient.getObject[String](location).futureValue
       obj.get.content shouldBe body
@@ -173,7 +173,7 @@ class PlayObjectStoreClientSpec
 
       initGetObjectStub(location, statusCode = 200, Some(body))
 
-      import InMemoryReads._
+      import InMemoryReads.jsValueContentRead
 
       val obj = osClient.getObject[JsValue](location).futureValue
       obj.get.content shouldBe JsObject(Seq("k1" -> JsString("v1"), "k2" -> JsString("v2")))
@@ -186,7 +186,7 @@ class PlayObjectStoreClientSpec
 
       initGetObjectStub(location, statusCode = 200, Some(body))
 
-      import InMemoryReads._
+      import InMemoryReads.jsValueContentRead
 
       osClient.getObject[JsValue](location).failed.futureValue shouldBe an[Exception]
     }


### PR DESCRIPTION
Implements the play instances in `Future[Either[PlayObjectStoreException,*]]` rather than `Future` (written generically in terms of `PlayMonad`).
Provides a `NaturalTransformation` to transform the client return values. Clients provided for both `Future` and `Future[Either[PlayObjectStoreException,*]]`