### PR TITLE
BDOG-1037: Removed content-type from ObjectSummary

### DIFF
--- a/object-store-client-common/src/main/scala/uk/gov/hmrc/objectstore/client/model/objectstore/ObjectSummary.scala
+++ b/object-store-client-common/src/main/scala/uk/gov/hmrc/objectstore/client/model/objectstore/ObjectSummary.scala
@@ -20,7 +20,6 @@ import java.time.Instant
 
 final case class ObjectSummary(
   location     : String,
-  contentType  : String,
   contentLength: Long,
   contentMd5   : String,
   lastModified : Instant

--- a/object-store-client-play-26/src/main/scala/uk/gov/hmrc/objectstore/client/play/PlayFormats.scala
+++ b/object-store-client-play-26/src/main/scala/uk/gov/hmrc/objectstore/client/play/PlayFormats.scala
@@ -26,7 +26,6 @@ object PlayFormats {
 
   val objectSummaryRead: Reads[ObjectSummary] =
     ( (__ \ "location"     ).read[String].map(_.stripPrefix("/object-store/object/"))
-    ~ (__ \ "contentType"  ).read[String]
     ~ (__ \ "contentLength").read[Long]
     ~ (__ \ "contentMD5"   ).read[String]
     ~ (__ \ "lastModified" ).read[Instant]

--- a/object-store-client-play-26/src/test/scala/uk/gov/hmrc/objectstore/client/play/PlayObjectStoreClientEitherSpec.scala
+++ b/object-store-client-play-26/src/test/scala/uk/gov/hmrc/objectstore/client/play/PlayObjectStoreClientEitherSpec.scala
@@ -259,14 +259,12 @@ class PlayObjectStoreClientEitherSpec
       osClient.listObjects(location).futureValue.right.value.objectSummaries shouldBe List(
         ObjectSummary(
           location      = "something/0993180f-8f31-41b2-905c-71f0273bb7d4",
-          contentType   = "application/json",
           contentLength = 49,
           contentMd5    = "4033ff85a6fdc6a2f51e60d89236a244",
           lastModified  = Instant.parse("2020-07-21T13:16:42.859Z")
         ),
         ObjectSummary(
           location      = "something/23265eab-268e-4fcc-904f-775586b362c2",
-          contentType   = "application/json",
           contentLength = 49,
           contentMd5    = "a3c2f1e38701bd2c7b54ebd7b1cd0dbc",
           lastModified  = Instant.parse("2020-07-21T13:16:41.226Z")

--- a/object-store-client-play-26/src/test/scala/uk/gov/hmrc/objectstore/client/play/PlayObjectStoreClientSpec.scala
+++ b/object-store-client-play-26/src/test/scala/uk/gov/hmrc/objectstore/client/play/PlayObjectStoreClientSpec.scala
@@ -259,14 +259,12 @@ class PlayObjectStoreClientSpec
       osClient.listObjects(location).futureValue.objectSummaries shouldBe List(
         ObjectSummary(
           location      = "something/0993180f-8f31-41b2-905c-71f0273bb7d4",
-          contentType   = "application/json",
           contentLength = 49,
           contentMd5    = "4033ff85a6fdc6a2f51e60d89236a244",
           lastModified  = Instant.parse("2020-07-21T13:16:42.859Z")
         ),
         ObjectSummary(
           location      = "something/23265eab-268e-4fcc-904f-775586b362c2",
-          contentType   = "application/json",
           contentLength = 49,
           contentMd5    = "a3c2f1e38701bd2c7b54ebd7b1cd0dbc",
           lastModified  = Instant.parse("2020-07-21T13:16:41.226Z")


### PR DESCRIPTION
This PR removes reading `contentType` from the list endpoint JSON response as the object-store API will not return `contentType` metadata in the list endpoint response.